### PR TITLE
Removed v-mapbox dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ npm init vue@latest
 cd globewatch
 npm install
 npm run lint
-npm install --save v-mapbox mapbox-gl
+npm install --save mapbox-gl
 npm run dev
 ```

--- a/frontend/globewatch/package-lock.json
+++ b/frontend/globewatch/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "core-js": "3.21.1",
         "mapbox-gl": "^1.13.2",
-        "v-mapbox": "^3.3.1",
         "vue": "^3.2.45"
       },
       "devDependencies": {
@@ -3010,20 +3009,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/v-mapbox": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/v-mapbox/-/v-mapbox-3.3.1.tgz",
-      "integrity": "sha512-2UNFum2JShe+kw+rbJySM6eJPz+KZJp3XKn4Kqin/xfvlQrcFjw8VuKK1F3ekAmxhtA8/7s8dtabyJ2+T9Ciig==",
-      "optionalDependencies": {
-        "@deck.gl/core": "^8.8.3",
-        "@deck.gl/layers": "^8.8.3",
-        "@deck.gl/mapbox": "^8.8.3"
-      },
-      "peerDependencies": {
-        "mapbox-gl": "1.13.2",
-        "vue": "^3.2.37"
-      }
-    },
     "node_modules/vite": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.2.tgz",
@@ -5375,16 +5360,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "v-mapbox": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/v-mapbox/-/v-mapbox-3.3.1.tgz",
-      "integrity": "sha512-2UNFum2JShe+kw+rbJySM6eJPz+KZJp3XKn4Kqin/xfvlQrcFjw8VuKK1F3ekAmxhtA8/7s8dtabyJ2+T9Ciig==",
-      "requires": {
-        "@deck.gl/core": "^8.8.3",
-        "@deck.gl/layers": "^8.8.3",
-        "@deck.gl/mapbox": "^8.8.3"
-      }
     },
     "vite": {
       "version": "4.0.2",

--- a/frontend/globewatch/package.json
+++ b/frontend/globewatch/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "core-js": "3.21.1",
     "mapbox-gl": "^1.13.2",
-    "v-mapbox": "^3.3.1",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/frontend/globewatch/src/App.vue
+++ b/frontend/globewatch/src/App.vue
@@ -1,44 +1,28 @@
 <template>
   <main class="w-screen h-screen">
-    <v-map class="w-full h-full" :options="state.map" />
+    <div id="mapContainer" class="w-full h-full"></div>
   </main>
 </template>
 
 <script>
-import 'mapbox-gl/dist/mapbox-gl.css'
-import 'v-mapbox/dist/v-mapbox.css';
-
-import VMap from "v-mapbox";
-import { reactive } from "vue";
+import mapboxgl from "mapbox-gl";
 
 export default {
-  name: "App",
-  components: {
-    VMap,
-  },
-  setup() {
-    const state = reactive({
-      map: {
-        accessToken:
-          "pk.eyJ1Ijoic29jaWFsZXhwbG9yZXIiLCJhIjoiREFQbXBISSJ9.dwFTwfSaWsHvktHrRtpydQ",
-        style: "mapbox://styles/mapbox/satellite-streets-v12?optimize=true",
-        center: [20.23928, 7.35074],
-        zoom: 5,
-        maxZoom: 22,
-        crossSourceCollisions: false,
-        failIfMajorPerformanceCaveat: false,
-        attributionControl: false,
-        preserveDrawingBuffer: true,
-        hash: false,
-        minPitch: 0,
-        maxPitch: 60,
-      },
-    });
-
+  name: "BaseMap",
+  data() {
     return {
-      state,
+      accessToken: "pk.eyJ1Ijoic29jaWFsZXhwbG9yZXIiLCJhIjoiREFQbXBISSJ9.dwFTwfSaWsHvktHrRtpydQ"
     };
   },
+  mounted() {
+    mapboxgl.accessToken = this.accessToken;
+    new mapboxgl.Map({
+      container: "mapContainer",
+      style: "mapbox://styles/mapbox/satellite-streets-v12?optimize=true",
+      center: [20.23928, 7.35074],
+      zoom: 5,
+    });
+  }
 };
 </script>
 


### PR DESCRIPTION
## Description

Following the realisation that [v-mapbox](https://github.com/geospoc/v-mapbox) is not as maintained as once thought, I removed the **v-mapbox** dependency and replaced it with vanilla **mapboxgl**. We may have to make the map "reactive" again, as I used the basic code from [this post](https://dev.to/hmintoh/how-to-mapbox-with-vue-js-2a34).

I manually edited `package.json` and `package-lock.json` to remove all v-mapbox related code, which I'm unsure if that was the right way.

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions/changes to the documentation


## User Experience:

The same user experience can be expected.
